### PR TITLE
1.1.1-pl

### DIFF
--- a/_build/config.inc.php
+++ b/_build/config.inc.php
@@ -8,7 +8,7 @@
 $config = [
     'name' => 'VueTools',
     'name_lower' => 'vuetools',
-    'version' => '1.1.0',
+    'version' => '1.1.1',
     'release' => 'pl',
     'author' => 'Nikolay Savin',
     'telegram' => 'biz87',

--- a/core/components/vuetools/docs/changelog.txt
+++ b/core/components/vuetools/docs/changelog.txt
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1-pl] - 2026-02-10
+
+### Fixed
+- Missing `usePrimeVueLocale.min.js` file in build
+
+### Changed
+- Updated dependencies
+
 ## [1.1.0-pl] - 2026-02-05
 
 ### Added

--- a/core/components/vuetools/src/VueCore.php
+++ b/core/components/vuetools/src/VueCore.php
@@ -13,7 +13,7 @@ use MODX\Revolution\modX;
  */
 class VueCore
 {
-    public const VERSION = '1.0.0-beta1';
+    public const VERSION = '1.1.1-pl';
 
     protected modX $modx;
     protected array $namespace;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "vuetools",
-  "version": "1.1.0-beta1",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vuetools",
-      "version": "1.1.0-beta1",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@primevue/themes": "^4.3.1",
         "pinia": "^3.0.1",
         "primeicons": "^7.0.0",
-        "primelocale": "^2.2.4",
+        "primelocale": "~2.2.4",
         "primevue": "^4.3.1",
         "vue": "^3.5.13"
       },


### PR DESCRIPTION
### Что оно делает?

Обновил зависимости
Добавил в сборку пропущенный `usePrimeVueLocale.min.js`
Поднял версию до 1.1.1

### Зачем это нужно?

В сборке отсутствовал файл


