### PR TITLE
fix(vuetools): add VueTools\Service for MODX service container

### DIFF
--- a/core/components/vuetools/model/vuetools/Service.php
+++ b/core/components/vuetools/model/vuetools/Service.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * VueTools Service
+ *
+ * Entry point for MODX service container. Extends VueCore so that
+ * getService('vuetools') / $modx->services->get('vuetools') resolve correctly.
+ *
+ * @package VueTools
+ */
+
+namespace VueTools;
+
+// VueCore lives in src/; ensure it is loadable when this file is loaded from model/
+if (!class_exists(VueCore::class, false)) {
+    require_once dirname(__DIR__, 2) . '/src/VueCore.php';
+}
+
+class Service extends VueCore
+{
+}


### PR DESCRIPTION
MODX 3 resolves the `vuetools` service by loading class `VueTools\Service` from `model/vuetools/`. The component only had `VueCore` in `src/` and registered the service via a closure in bootstrap, so xPDO attempted the conventional class load first and failed with "Could not load class: VueTools\Service from vuetools\service".

```
[2026-03-02 06:41:43] (ERROR @ /home/c/ck19835/ms3/public_html/core/vendor/xpdo/xpdo/src/xPDO/xPDO.php : 667) Could not load class: VueTools\Service from vuetools\service
[2026-03-02 06:41:43] (ERROR @ /home/c/ck19835/ms3/public_html/core/vendor/xpdo/xpdo/src/xPDO/xPDO.php : 1273) Problem getting service vueTools, instance of class VueTools\Service, from path /home/c/ck19835/ms3/public_html/core/components/vuetools/model/vuetools/
```

Add `core/components/vuetools/model/vuetools/Service.php` that extends `VueCore` and explicitly requires `VueCore.php` so the class is loadable regardless of bootstrap/autoload order. `$modx->services->get('vuetools')` then resolves to the same behaviour (Import Map, styles, etc.) without errors.

No build changes: the package already ships the full `core/components/vuetools/` tree, so the new `model/` directory is included automatically.