### PR TITLE
fix(vuecore): sync hardcoded $versions with shipped bundles

### DIFF
--- a/core/components/vuetools/src/VueCore.php
+++ b/core/components/vuetools/src/VueCore.php
@@ -25,9 +25,9 @@ class VueCore
      * Library versions
      */
     protected array $versions = [
-        'vue' => '3.5.13',
-        'pinia' => '3.0.1',
-        'primevue' => '4.3.1',
+        'vue' => '3.5.32',
+        'pinia' => '3.0.4',
+        'primevue' => '4.5.5',
         'primeicons' => '7.0.0',
     ];
 


### PR DESCRIPTION
## Проблема

В [#9](https://github.com/modx-pro/vueTools/pull/9) подняли build-зависимости (`vue 3.5.32`, `pinia 3.0.4`, `primevue 4.5.5`), но захардкоженный массив `$versions` в `core/components/vuetools/src/VueCore.php` остался со старыми `3.5.13 / 3.0.1 / 4.3.1`.

Метод `getVersions()` отдаёт этот массив наружу, поэтому после #9 он сообщает версии, которые **не совпадают** с реально шипуемыми vendor-бандлами (`assets/components/vuetools/vendor/*.min.js`, пересобираемыми из `package.json`).

## Решение

Синхронизировал массив с `package.json`:

| dep | было | стало |
|-----|------|-------|
| vue | 3.5.13 | 3.5.32 |
| pinia | 3.0.1 | 3.0.4 |
| primevue | 4.3.1 | 4.5.5 |
| primeicons | 7.0.0 | 7.0.0 (без изменений) |

Скоуп минимальный — только устранение рассинхрона. `VueCore::VERSION` намеренно не трогаю (бамп версии пакета — отдельное решение для релиза).

🤖 Generated with [Claude Code](https://claude.com/claude-code)