### PR TITLE
chore(release): 1.1.2-pl

### DIFF
--- a/_build/config.inc.php
+++ b/_build/config.inc.php
@@ -8,7 +8,7 @@
 $config = [
     'name' => 'VueTools',
     'name_lower' => 'vuetools',
-    'version' => '1.1.1',
+    'version' => '1.1.2',
     'release' => 'pl',
     'author' => 'Nikolay Savin',
     'telegram' => 'biz87',

--- a/core/components/vuetools/docs/changelog.txt
+++ b/core/components/vuetools/docs/changelog.txt
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2-pl] - 2026-06-15
+
+### Added
+- `VueTools\Service` class so MODX resolves the `vuetools` service via the conventional `model/vuetools/` path (#6)
+
+### Changed
+- Migrated PrimeVue theme package `@primevue/themes` to the maintained `@primeuix/themes` (#9)
+- Updated bundled stack: Vue 3.5.32, Pinia 3.0.4, PrimeVue 4.5.5; `primelocale` ^2.3.1 (#9)
+- Synced hardcoded `$versions` in `VueCore` with the shipped bundles (#13)
+- Bumped `postcss` to 8.5.15 — includes security fixes (#12)
+
 ## [1.1.1-pl] - 2026-02-10
 
 ### Fixed

--- a/core/components/vuetools/src/VueCore.php
+++ b/core/components/vuetools/src/VueCore.php
@@ -13,7 +13,7 @@ use MODX\Revolution\modX;
  */
 class VueCore
 {
-    public const VERSION = '1.1.1-pl';
+    public const VERSION = '1.1.2-pl';
 
     protected modX $modx;
     protected array $namespace;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vuetools",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vuetools",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@primeuix/themes": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetools",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Vue core stack for MODX Revolution 3.x components",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
@
Релиз патч-версии **1.1.2-pl** с уже влитыми изменениями.

## Бамп версии (выровнено по всем точкам)

| Файл | Было | Стало |
|---|---|---|
| `core/components/vuetools/src/VueCore.php` (`VERSION`) | 1.1.1-pl | **1.1.2-pl** |
| `_build/config.inc.php` (`version`) | 1.1.1 | **1.1.2** |
| `package.json` | 1.1.0 *(отставал)* | **1.1.2** |
| `package-lock.json` (root) | 1.1.0 | **1.1.2** |

## Что вошло в 1.1.2 (с момента 1.1.1)

- **Added:** класс `VueTools\Service` — MODX резолвит сервис `vuetools` по конвенции `model/vuetools/` ([#6](https://github.com/modx-pro/vueTools/pull/6))
- **Changed:** миграция темы `@primevue/themes` → `@primeuix/themes` ([#9](https://github.com/modx-pro/vueTools/pull/9))
- **Changed:** обновление стека — Vue 3.5.32, Pinia 3.0.4, PrimeVue 4.5.5, primelocale ^2.3.1 ([#9](https://github.com/modx-pro/vueTools/pull/9))
- **Changed:** синхронизация захардкоженного `$versions` в `VueCore` с шипуемыми бандлами ([#13](https://github.com/modx-pro/vueTools/pull/13))
- **Changed:** postcss → 8.5.15 (фиксы безопасности) ([#12](https://github.com/modx-pro/vueTools/pull/12))

Обновлён `core/components/vuetools/docs/changelog.txt`.

## Не входит

- Vite 8 ([#10](https://github.com/modx-pro/vueTools/pull/10)) — закрыт, ждёт отдельного фикс-PR в одном окне с MiniShop3.

## Перед сборкой transport-пакета

Версия в коде поднята. Сам пакет собирается отдельно: `npm run build:all` (vendor-бандлы git-ignored) → `php _build/build.php`. Контракт import map не менялся — потребители (MiniShop3 и 6 компонентов) не затронуты.
@