### PR TITLE
fix: one VueTools service under vuetools and vueTools

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -53,6 +53,10 @@ VueTools регистрирует Import Map в `<head>` страницы мен
 3. Подключает CSS стили PrimeVue (изолированы классом `.vueApp`)
 4. Ваш компонент загружает свои ES modules, которые импортируют из Import Map
 
+### Сервис VueTools
+
+Канонический доступ: `$modx->services->get('vuetools')`. Ключ `vueTools` и `getService('vueTools', 'VueTools\Service', …)` возвращают тот же объект. Не вызывайте `new \VueTools\Service` в extras: флаги Import Map и CSS живут на экземпляре.
+
 ---
 
 ## Локализация PrimeVue

--- a/core/components/vuetools/bootstrap.php
+++ b/core/components/vuetools/bootstrap.php
@@ -2,11 +2,21 @@
 /**
  * VueTools bootstrap
  *
+ * One shared Service under both container keys:
+ * - `vuetools` (canonical; VueCoreManager and most extras)
+ * - `vueTools` (camelCase from getService / $modx->vueTools)
+ *
+ * Without the alias, bootstrap and getService each get their own object and
+ * separate importMapRegistered / stylesIncluded flags (#11).
+ *
+ * Autoload maps VueTools\* → src/. Service lives in model/vuetools/ for xPDO
+ * getService path loading; that file requires VueCore itself.
+ *
  * @var \MODX\Revolution\modX $modx
  * @var array $namespace
  */
 
-// Register autoloader for VueTools namespace
+// Register autoloader for VueTools namespace (src/ only; Service is model/)
 spl_autoload_register(function ($class) {
     $prefix = 'VueTools\\';
     $baseDir = __DIR__ . '/src/';
@@ -24,6 +34,19 @@ spl_autoload_register(function ($class) {
     }
 });
 
+// Ensure Service is loadable when the factory runs (autoload does not cover model/)
+if (!class_exists(\VueTools\Service::class, false)) {
+    require_once __DIR__ . '/model/vuetools/Service.php';
+}
+
 $modx->services->add('vuetools', function ($c) use ($modx, $namespace) {
-    return new \VueTools\VueCore($modx, $namespace);
+    $service = new \VueTools\Service($modx, $namespace);
+    // BC for extras that call getService('vueTools') and then check $modx->vueTools
+    $modx->vueTools = $service;
+
+    return $service;
+});
+
+$modx->services->add('vueTools', function ($c) {
+    return $c->get('vuetools');
 });

--- a/core/components/vuetools/docs/changelog.txt
+++ b/core/components/vuetools/docs/changelog.txt
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- One VueTools service under both `vuetools` and `vueTools` keys, so Import Map and CSS are not registered twice (#11)
+
 ## [1.1.2-pl] - 2026-06-15
 
 ### Added

--- a/core/components/vuetools/elements/plugins/vuecoremanager.php
+++ b/core/components/vuetools/elements/plugins/vuecoremanager.php
@@ -20,7 +20,7 @@ switch ($modx->event->name) {
             break;
         }
 
-        /** @var \VueTools\VueCore $vueCore */
+        /** @var \VueTools\Service $vueCore */
         $vueCore = $modx->services->get('vuetools');
 
         // Register Import Map and include CSS

--- a/core/components/vuetools/model/vuetools/Service.php
+++ b/core/components/vuetools/model/vuetools/Service.php
@@ -2,8 +2,14 @@
 /**
  * VueTools Service
  *
- * Entry point for MODX service container. Extends VueCore so that
- * getService('vuetools') / $modx->services->get('vuetools') resolve correctly.
+ * MODX 3 getService('vueTools', 'VueTools\Service', …) entry.
+ * Empty VueCore subclass so extras can use `instanceof \VueTools\Service`.
+ *
+ * bootstrap.php creates one instance and shares it under `vuetools` and
+ * `vueTools` (#11). Prefer the container; do not `new Service` in extras.
+ *
+ * File path is model/vuetools/ for xPDO. Package autoload only maps
+ * VueTools\* → src/, so VueCore is required below.
  *
  * @package VueTools
  */


### PR DESCRIPTION
## Summary
- Bootstrap creates one `\VueTools\Service` and registers it as both `vuetools` and `vueTools`, plus `$modx->vueTools` for BC.
- Stops duplicate Import Map / CSS when extras use `getService('vueTools', …)` alongside the plugin (#11).
- Short note in DEVELOPER_GUIDE; changelog under Unreleased.

Fixes #11

## Test plan
- [x] Local MODX: `services->get('vuetools') === get('vueTools') === getService('vueTools', 'VueTools\Service', …)` (same `spl_object_id`)
- [x] Double `include()` on both handles stays idempotent
- [ ] Install transport on a site that also loads an extra via `getService('vueTools')` and confirm one import map in page source