### PR TITLE
chore(deps): consolidate security bumps (supersedes #15–#18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,10 @@
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.4",
         "cross-env": "^10.1.0",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.26",
         "postcss-prefix-selector": "^2.1.1",
         "rimraf": "^6.1.3",
-        "vite": "^6.4.2"
+        "vite": "^6.4.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1121,16 +1121,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/copy-anything": {
@@ -1375,9 +1375,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1473,9 +1473,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1492,7 +1492,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1684,9 +1684,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,14 +26,18 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.4",
     "cross-env": "^10.1.0",
-    "postcss": "^8.5.15",
+    "postcss": "^8.5.26",
     "postcss-prefix-selector": "^2.1.1",
     "rimraf": "^6.1.3",
-    "vite": "^6.4.2"
+    "vite": "^6.4.3"
   },
   "engines": {
     "node": ">=18.0.0"
   },
   "author": "modx.pro",
-  "license": "MIT"
+  "license": "MIT",
+  "overrides": {
+    "nanoid": "^3.3.18",
+    "brace-expansion": "^5.0.9"
+  }
 }


### PR DESCRIPTION
## Summary
- Closes the four Dependabot PRs in one change with the versions that actually clear advisories.
- `vite` **6.4.3** (not 8.x from #15 — major upgrade is separate work; alerts are fixed at 6.4.3).
- `postcss` **8.5.26** (covers #17 / need ≥8.5.23).
- `overrides`: `nanoid` **^3.3.18**, `brace-expansion` **^5.0.9** (#16 only went to 5.0.7, which is still vulnerable; #18 covered by override).
- Leaves `@vitejs/plugin-vue` on 5.x for Vite 6.

Supersedes #15 #16 #17 #18

## Test plan
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm run build:all` on Vite 6.4.3